### PR TITLE
Display the parent folder's title when searching

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -29,7 +29,7 @@ function buildItems(bookmarkItem, indent) {
             const getParentBookmark = browser.bookmarks.get(bookmarkItem.parentId);
             getParentBookmark.then((bookmark) => {
                 folderInformation.parentTitle = bookmark[0].title;
-            }),
+            });
 
             globalBookmarkFolderTreeInformation.push(folderInformation);
             indentProgress += 1;

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -6,7 +6,7 @@
  * =================================================================================================
  */
 
-const gobalBookmarkFolderTreeInformation = [];
+const globalBookmarkFolderTreeInformation = [];
 
 /*
  * =================================================================================================
@@ -31,7 +31,7 @@ function buildItems(bookmarkItem, indent) {
                 folderInformation.parentTitle = bookmark[0].title;
             }),
 
-            gobalBookmarkFolderTreeInformation.push(folderInformation);
+            globalBookmarkFolderTreeInformation.push(folderInformation);
             indentProgress += 1;
         }
     }
@@ -95,7 +95,7 @@ function performSearch(input) {
     // Perform search based on user input
     const searchFilter = input.originalTarget.value.toLowerCase();
     if (searchFilter.length > 0) {
-        const results = gobalBookmarkFolderTreeInformation.filter(bookmarkFolder =>
+        const results = globalBookmarkFolderTreeInformation.filter(bookmarkFolder =>
             bookmarkFolder.title.toLowerCase().includes(searchFilter),
         );
         // Add each result to the displayed list or display information message

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -104,8 +104,12 @@ function performSearch(input) {
             results.forEach(result => {
                 const node = document.createElement('li');
                 const link = document.createElement('a');
-                const textnode = document.createTextNode(`${result.parentTitle}/${result.title}`);
-                link.appendChild(textnode);
+                const folder = document.createElement('strong');
+                const folderParentTitle = document.createTextNode(result.parentTitle + '/');
+                const folderTitle = document.createTextNode(result.title);
+                folder.appendChild(folderTitle);
+                link.appendChild(folderParentTitle);
+                link.appendChild(folder);
                 link.dataset.folderId = result.id;
                 node.appendChild(link);
                 node.addEventListener('click', saveBookmarkTo);

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -27,6 +27,9 @@ function buildItems(bookmarkItem, indent) {
                 id: bookmarkItem.id,
             };
             const getParentBookmark = browser.bookmarks.get(bookmarkItem.parentId);
+            getParentBookmark.then((bookmark) => {
+                folderInformation.parentTitle = bookmark[0].title;
+            }),
 
             gobalBookmarkFolderTreeInformation.push(folderInformation);
             indentProgress += 1;

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -26,6 +26,8 @@ function buildItems(bookmarkItem, indent) {
                 title: !bookmarkItem.title ? UNNAMED_FOLDER : bookmarkItem.title,
                 id: bookmarkItem.id,
             };
+            const getParentBookmark = browser.bookmarks.get(bookmarkItem.parentId);
+
             gobalBookmarkFolderTreeInformation.push(folderInformation);
             indentProgress += 1;
         }

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -104,7 +104,7 @@ function performSearch(input) {
             results.forEach(result => {
                 const node = document.createElement('li');
                 const link = document.createElement('a');
-                const textnode = document.createTextNode(result.title);
+                const textnode = document.createTextNode(`${result.parentTitle}/${result.title}`);
                 link.appendChild(textnode);
                 link.dataset.folderId = result.id;
                 node.appendChild(link);


### PR DESCRIPTION
I primarily use the quick bookmark popup but I have many bookmark folders with duplicate names in different parent folders. This change makes it easier to find the right one.

Before:
![no_parent_folders](https://user-images.githubusercontent.com/28141754/55139896-85238d80-513f-11e9-9f07-472d9191a16a.png)

After:
![with_parent_folders](https://user-images.githubusercontent.com/28141754/55143920-68d81e80-5148-11e9-8d43-fe77e7b7a508.png)

