### PR TITLE
Update 5 messages.json

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -6,10 +6,13 @@
     "message": "Das Symbol ist deaktiviert. Aktivieren Sie es in den Einstellungen des Add-ons."
   },
   "manifest_browser_action_default_title": {
-    "message": "Schnelles Setzen von Lesezeichen im Ordner"
+    "message": "Schnelles Setzen eines Lesezeichens im Ordner"
   },
   "manifest_shortcut_quick_bookmark_description": {
-    "message": "Tastenkürzel zum schnellen Setzen von Lesezeichen auf der aktuellen Seite."
+    "message": "Schnelles Setzen eines Lesezeichens für die aktuelle Seite"
+  },
+  "manifest_shortcut_browser_action_description": {
+    "message": "Schnelles Setzen eines Lesezeichens in einem Ordner"
   },
   "icon_remove_bookmark": {
     "message": "Lesezeichen für diese Seite entfernen"
@@ -51,7 +54,7 @@
     "message": "Verstanden!"
   },
   "options_title": {
-    "message": "Optionen für Standard-Lesezeichenordner"
+    "message": "Optionen für Default Bookmark Folder"
   },
   "options_thank_you": {
     "message": "Vielen Dank für die Nutzung dieses Add-ons!"
@@ -78,10 +81,10 @@
     "message": "Zugang zum Changelog"
   },
   "options_ff_built_in_note": {
-    "message": "Folgende Einstellungen gelten nur für das eingebaute Lesezeichensystem von Firefox. Sie können auswählen, in welchem Ordner (und an welcher Stelle dieses Ordners) die neuen Lesezeichen hinzugefügt werden. Sie betreffen nur Lesezeichen, die über das eingebaute Lesezeichensymbol, die Tastenkombination Strg+D, das Kontextmenü oder das Lesezeichen-Menü hinzugefügt werden."
+    "message": "Folgende Einstellungen gelten nur für die eingebaute Lesezeichenfunktion von Firefox. Sie können auswählen, in welchem Ordner und an welcher Stelle dieses Ordners die neuen Lesezeichen hinzugefügt werden. Sie betreffen nur Lesezeichen, die über das eingebaute Lesezeichensymbol, die Tastenkombination Strg+D, das Kontextmenü oder das Lesezeichen-Menü hinzugefügt werden."
   },
   "options_ff_built_in_folder": {
-    "message": "Wählen Sie, wo neue Lesezeichen hinzugefügt werden sollen:"
+    "message": "Wählen Sie aus, wo neue Lesezeichen hinzugefügt werden sollen:"
   },
   "options_ff_built_in_folder_default": {
     "message": "Kein Ordner ausgewählt (Standard-Lesezeichenspeicherort von Firefox wird verwendet)"
@@ -99,7 +102,7 @@
     "message": "Wenn deaktiviert, werden neue Lesezeichen am Ende des ausgewählten Ordners hinzugefügt."
   },
   "options_ff_built_in_folder_all_tabs_note": {
-    "message": "Folgende Einstellungen gelten nur, wenn Sie mehrere ausgewählte Tabs gleichzeitig mit einem Lesezeichen versehen oder die Funktion \"Tabs als Lesezeichen hinzufügen...\" für alle geöffneten Tabs verwenden. Damit können Sie den Standard-Speicherort des neu erstellten Ordners, der je nach Funktion ein Lesezeichen für alle ausgewählten oder geöffneten Tab enthält, sowie die Position des Ordners an diesem Speicherort überschreiben."
+    "message": "Folgende Einstellungen gelten nur, wenn Sie mehrere ausgewählte Tabs gleichzeitig mit einem Lesezeichen versehen oder die Funktion \"Tabs als Lesezeichen hinzufügen...\" für alle geöffneten Tabs verwenden. Damit können Sie den Standard-Speicherort des neu erstellten Ordners, der je nach Funktion ein Lesezeichen für alle ausgewählten oder geöffneten Tabs enthält, sowie die Position des Ordners an diesem Speicherort überschreiben."
   },
   "options_ff_built_in_folder_all_tabs": {
     "message": "Wählen Sie aus, wo neue Ordner der mit Lesezeichen versehenen Tabs hinzugefügt werden sollen:"
@@ -132,13 +135,13 @@
     "message": "Schnelles Lesezeichen-Kontextmenü aktivieren"
   },
   "options_icon_enable_context_menu_help": {
-    "message": "Schnelles Setzen von Lesezeichen über das Seiten-Kontextmenü oder direkt in einen bestimmten Ordner über dessen Kontextmenü (benötigt Firefox 59+)"
+    "message": "Schnelles Setzen von Lesezeichen über das Seiten-Kontextmenü oder direkt in einem bestimmten Ordner über dessen Kontextmenü (benötigt Firefox 59+)"
   },
   "options_icon_note": {
     "message": "Folgende Einstellungen gelten nur für die schnelle Lesezeichenfunktion."
   },
   "options_icon_folder": {
-    "message": "Wählen Sie, wo neue Lesezeichen hinzugefügt werden sollen:"
+    "message": "Wählen Sie aus, wo neue Lesezeichen hinzugefügt werden sollen:"
   },
   "options_icon_folder_default": {
     "message": "Kein Ordner ausgewählt (Standard-Lesezeichenspeicherort von Firefox wird verwendet)"
@@ -156,22 +159,22 @@
     "message": "Wenn deaktiviert, werden neue Lesezeichen am Ende des ausgewählten Ordners hinzugefügt."
   },
   "options_icon_inbox": {
-    "message": "Schnelles Lesezeichensymbol für die Seite nur dann farbig anzeigen, wenn sich alle Lesezeichen dieser Seite in dem oben ausgewählten Ordner befinden"
+    "message": "Schnelles Lesezeichensymbol für die Seite nur dann farbig anzeigen, wenn sich alle Lesezeichen dieser Seite im oben ausgewählten Ordner befinden"
   },
   "options_icon_inbox_help": {
-    "message": "Wenn diese Einstellung aktiviert ist, wird das schnelle Lesezeichensymbol nur dann farbig dargestellt (d. h., die aktuelle Seite wurde mit einem Lesezeichen versehen), wenn sich alle Lesezeichen dieser Seite in dem oben von Ihnen ausgewählten Ordner befinden"
+    "message": "Wenn diese Einstellung aktiviert ist, wird das schnelle Lesezeichensymbol nur dann farbig dargestellt (d. h., die aktuelle Seite wurde mit einem Lesezeichen versehen), wenn sich alle Lesezeichen dieser Seite im oben ausgewählten Ordner befinden."
   },
   "options_icon_prevent_removal": {
     "message": "Entfernung von Lesezeichen verhindern"
   },
   "options_icon_prevent_removal_help": {
-    "message": "Wenn diese Einstellung aktiviert ist, kann das schnelle Lesezeichensystem (Symbol, Tastenkürzel und Kontextmenü) keine Lesezeichen entfernen, aber immer noch neue erstellen."
+    "message": "Wenn diese Einstellung aktiviert ist, kann die schnelle Lesezeichenfunktion (Symbol, Tastenkürzel und Kontextmenü) keine Lesezeichen entfernen, aber immer noch neue erstellen."
   },
   "options_icon_color": {
     "message": "Symbolfarbe wählen, wenn die aktuelle Seite mit einem Lesezeichen versehen ist:"
   },
   "options_icon_color_default": {
-    "message": "Standard ist die Symbolfarbe rot, wenn die aktuelle Seite mit einem Lesezeichen versehen ist."
+    "message": "Standard ist die Symbolfarbe rot."
   },
   "options_color_black": {
     "message": "Schwarz"
@@ -222,7 +225,7 @@
     "message": "Lizenz:"
   },
   "popup_quick_bookmarking_folder_title": {
-    "message": "Schnelles Setzen von Lesezeichen im Ordner"
+    "message": "Schnelles Setzen eines Lesezeichens im Ordner:"
   },
   "popup_quick_bookmarking_folder_info": {
     "message": "Ordner suchen und auswählen, in dem die aktuelle Seite als Lesezeichen gespeichert werden soll."
@@ -231,7 +234,7 @@
     "message": "Ordner suchen..."
   },
   "popup_quick_bookmarking_folder_not_found": {
-    "message": "Es wurden keine passenden Ordner gefunden."
+    "message": "Es wurde kein passender Ordner gefunden."
   },
   "popup_quick_bookmarking_folder_save_error": {
     "message": "Beim Speichern des Lesezeichens ist ein Fehler aufgetreten."

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -9,7 +9,10 @@
     "message": "Quick bookmarking to folder"
   },
   "manifest_shortcut_quick_bookmark_description": {
-    "message": "Shortcut to quickly bookmark the current page."
+    "message": "Quickly bookmark the current page"
+  },
+  "manifest_shortcut_browser_action_description": {
+    "message": "Quickly bookmark to a folder"
   },
   "icon_remove_bookmark": {
     "message": "Remove the bookmark(s) for this page"
@@ -222,16 +225,16 @@
     "message": "License:"
   },
   "popup_quick_bookmarking_folder_title": {
-    "message": "Quick bookmarking to folder"
+    "message": "Quick bookmarking to folder:"
   },
   "popup_quick_bookmarking_folder_info": {
     "message": "Search and select a folder to bookmark the current page into it."
   },
   "popup_quick_bookmarking_folder_search": {
-    "message": "Search folders..."
+    "message": "Search folder..."
   },
   "popup_quick_bookmarking_folder_not_found": {
-    "message": "No matching folders were found."
+    "message": "No matching folder was found."
   },
   "popup_quick_bookmarking_folder_save_error": {
     "message": "An error happened when trying to save the bookmark."

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -9,7 +9,10 @@
     "message": "Quick bookmarking to folder"
   },
   "manifest_shortcut_quick_bookmark_description": {
-    "message": "Shortcut to quickly bookmark the current page."
+    "message": "Quickly bookmark the current page"
+  },
+  "manifest_shortcut_browser_action_description": {
+    "message": "Quickly bookmark to a folder"
   },
   "icon_remove_bookmark": {
     "message": "Supprimer le(s) marque-page(s) pour cette page"

--- a/src/_locales/hu/messages.json
+++ b/src/_locales/hu/messages.json
@@ -9,7 +9,10 @@
     "message": "Quick bookmarking to folder"
   },
   "manifest_shortcut_quick_bookmark_description": {
-    "message": "Shortcut to quickly bookmark the current page."
+    "message": "Quickly bookmark the current page"
+  },
+  "manifest_shortcut_browser_action_description": {
+    "message": "Quickly bookmark to a folder"
   },
   "icon_remove_bookmark": {
     "message": "Remove the bookmark(s) for this page"
@@ -222,16 +225,16 @@
     "message": "Licenc:"
   },
   "popup_quick_bookmarking_folder_title": {
-    "message": "Quick bookmarking to folder"
+    "message": "Quick bookmarking to folder:"
   },
   "popup_quick_bookmarking_folder_info": {
     "message": "Search and select a folder to bookmark the current page into it."
   },
   "popup_quick_bookmarking_folder_search": {
-    "message": "Search folders..."
+    "message": "Search folder..."
   },
   "popup_quick_bookmarking_folder_not_found": {
-    "message": "No matching folders were found."
+    "message": "No matching folder was found."
   },
   "popup_quick_bookmarking_folder_save_error": {
     "message": "An error happened when trying to save the bookmark."

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -9,7 +9,10 @@
     "message": "Quick bookmarking to folder"
   },
   "manifest_shortcut_quick_bookmark_description": {
-    "message": "Shortcut to quickly bookmark the current page."
+    "message": "Quickly bookmark the current page"
+  },
+  "manifest_shortcut_browser_action_description": {
+    "message": "Quickly bookmark to a folder"
   },
   "icon_remove_bookmark": {
     "message": "Удалить все закладки этой страницы"
@@ -222,7 +225,7 @@
     "message": "Лицензия:"
   },
   "popup_quick_bookmarking_folder_title": {
-    "message": "Quick bookmarking to folder"
+    "message": "Quick bookmarking to folder:"
   },
   "popup_quick_bookmarking_folder_info": {
     "message": "Найдите и выберите папку в которую вы хотите добавить закладку на текущую страницу."


### PR DESCRIPTION
- German translation improved

- English changes:
1. Added:
  "manifest_shortcut_browser_action_description": {
    "message": "Quickly bookmark to a folder"
  },
because in Firefox' "Manage Extension Shortcuts" stands "__ MSG_manifest_shortcut_browser_action_description__"

2. "message": "Shortcut to quickly bookmark the current page."
changed to
   "message": "Quickly bookmark the current page"
because in Firefox' "Manage Extension Shortcuts" all entries of other installed add-ons are formulated similarly (without "Shortcut to")

3. "message": "Search folders..."
and
   "message": "No matching folders were found."
folders changed to singular, because one folder is meant

- English changes added in French, Hungarian and Russian
